### PR TITLE
Feature/23 Rubocopのコーディング規約を更新

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,65 @@
 inherit_from: .rubocop_todo.yml
+
+
+#元々あるファイルなどは、対象外と言うことにする
+AllCops:
+  TargetRubyVersion: 2.5.1
+  TargetRailsVersion: 5.2.4
+  Exclude:
+    - 'vendor/**/*'
+    - 'bin/**/*'
+    - 'db/**/*'
+    - 'tmp/**/*'
+    - 'node_modules/**/*'
+    - 'lib/tasks/auto_annotate_models.rake'
+
+#クラスのコメント必須を無視
+Documentation:
+  Enabled: false
+
+# 日本語のコメントを許可する
+Style/AsciiComments:
+  Enabled: false
+
+# 20 行超えるのはmigration ファイル以外許可しない
+Metrics/MethodLength:
+  Max: 20
+  Exclude:
+    - "db/migrate/*.rb"
+
+# Offense count: 1
+# Cop supports --auto-correct.
+#ブロックコメントを使うのはやめる
+Style/BlockComments:
+  Exclude:
+    - 'spec/spec_helper.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: MinSize.
+# SupportedStyles: percent, brackets
+#原則％記法を使用しなければいけない。
+Style/SymbolArray:
+  EnforcedStyle: brackets
+
+# Offense count: 4
+# Cop supports --auto-correct.
+Layout/CommentIndentation:
+  Exclude:
+    - 'Gemfile'
+
+# モジュール名::クラス名の定義を許可
+ClassAndModuleChildren:
+  Enabled: false
+
+# Offense count: 39
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: always, always_true, never
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+#ブロックあたりの行数が長くなるのを許可する
+Metrics/BlockLength:
+  Enabled: false
+

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,14 +14,10 @@ Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Layout/CommentIndentation:
-  Exclude:
-    - 'Gemfile'
 
 # Offense count: 3
 # Cop supports --auto-correct.
+#空白を2行開けない様にする。
 Layout/EmptyLines:
   Exclude:
     - 'Gemfile'
@@ -42,27 +38,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
   Exclude:
     - 'config/environments/production.rb'
 
-# Offense count: 3
-# Configuration parameters: AllowedChars.
-Style/AsciiComments:
-  Exclude:
-    - 'Gemfile'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/BlockComments:
-  Exclude:
-    - 'spec/spec_helper.rb'
-
-# Offense count: 4
-Style/Documentation:
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-    - 'app/helpers/application_helper.rb'
-    - 'app/mailers/application_mailer.rb'
-    - 'app/models/application_record.rb'
-    - 'config/application.rb'
 
 # Offense count: 3
 # Cop supports --auto-correct.
@@ -72,12 +47,7 @@ Style/ExpandPathArguments:
     - 'bin/rake'
     - 'bin/rspec'
 
-# Offense count: 39
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, always_true, never
-Style/FrozenStringLiteralComment:
-  Enabled: false
+
 
 # Offense count: 2
 Style/MixinUsage:
@@ -107,10 +77,3 @@ Style/StringLiterals:
     - 'config/environments/production.rb'
     - 'config/puma.rb'
     - 'spec/rails_helper.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: MinSize.
-# SupportedStyles: percent, brackets
-Style/SymbolArray:
-  EnforcedStyle: brackets

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,6 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
   helper_method :owner?
 
-
-
   private
 
   def current_user

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :comment do
-    body { "This is a comment" }
+    body { 'This is a comment' }
     user
     food
   end


### PR DESCRIPTION
.rubocop.ymlと.rubocop_todo.ymlを更新
少し気になった所が合ったので、rubocop -aは避けた

before_actionで読み込んでいるけど、他にロジックを書いていないコントローラーとかでも、
`edit; end`
と書けと言われるので
動作しなくなるかもと思った。
まだ完全に修正できていないので、もう一度実施したいと思う。
#23 
