### PR TITLE
Feature/29 日本語に対応させる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'jquery-rails'
 # フロントエンド用にslimとbootstrapとfont-awesomeを導入
 gem 'kaminari'
 # ページネーションを追加
-
+gem 'rails-i18n'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.4.3)
       actionpack (= 5.2.4.3)
       activesupport (= 5.2.4.3)
@@ -300,6 +303,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.3)
+  rails-i18n
   rspec-rails (~> 3.7)
   rubocop-rails
   sass-rails (~> 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,6 @@ class ApplicationController < ActionController::Base
   end
 
   def owner?(some_object)
-    current_user == some_object.user
+    current_user == some_object.user if current_user
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -5,6 +5,7 @@ html
       | FoodApp
     = csrf_meta_tags
     = csp_meta_tag
+    meta[name="viewport" content="width=device-width, initial-scale=1.0"]
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   body
@@ -21,6 +22,7 @@ html
         - else
           li.nav-item= link_to 'ログイン', login_path, class: 'nav-link'
     .ml-5.mr-5
-      - if flash.notice.present?
-        .alert.alert-primary.text-black= flash.notice
-      = yield
+      .container
+        - if flash.notice.present?
+          .alert.alert-primary.text-black= flash.notice
+        = yield

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,10 @@ module FoodApp
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+    config.i18n.default_locale = :ja
+
     config.generators do |g|
       g.stylesheets false
       g.javascripts false

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -18,7 +18,11 @@ RSpec.describe Comment, type: :model do
       it 'is not allowed without body' do
         comment.body = nil
         comment.valid?
-        expect(comment.errors[:body]).to include "can't be blank"
+        if I18n.locale == :en
+          expect(comment.errors[:body]).to include "can't be blank"
+        else
+          expect(comment.errors[:body]).to include "を入力してください"
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,19 +13,31 @@ RSpec.describe User, type: :model do
     it 'is invalid without email' do
       user_a.email = nil
       user_a.valid?
-      expect(user_a.errors[:email]).to include "can't be blank"
+      if I18n.locale == :en
+        expect(user_a.errors[:email]).to include "can't be blank"
+      else
+        expect(user_a.errors[:email]).to include 'を入力してください'
+      end
     end
 
     it 'is invalid without nickname' do
       user_a.nickname = nil
       user_a.valid?
-      expect(user_a.errors[:nickname]).to include "can't be blank"
+      if I18n.locale == :en
+        expect(user_a.errors[:nickname]).to include "can't be blank"
+      else
+        expect(user_a.errors[:nickname]).to include 'を入力してください'
+      end
     end
 
     it 'is invalid nickname is too long' do
       user_a.nickname = 'a' * 16
       user_a.valid?
-      expect(user_a.errors[:nickname]).to include 'is too long (maximum is 15 characters)'
+      if I18n.locale == :en
+        expect(user_a.errors[:nickname]).to include 'is too long (maximum is 15 characters)'
+      else
+        expect(user_a.errors[:nickname]).to include 'は15文字以内で入力してください'
+      end
     end
   end
 end

--- a/spec/system/foods_spec.rb
+++ b/spec/system/foods_spec.rb
@@ -74,7 +74,11 @@ describe 'about foods function', type: :system do
         fill_in 'foods_description', with: ''
         select 'lunch', from: 'food_category_id'
         find('.btn.btn-default.text-white.mt-5.btn-round').click
-        expect(page).to have_content "Description can't be blank"
+        if I18n.locale == :en
+          expect(page).to have_content "Description can't be blank"
+        else
+          expect(page).to have_content 'Descriptionを入力してください'
+        end
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -51,7 +51,11 @@ describe 'about users function', type: :system do
         fill_in 'user_password_confirmation', with: 'password'
         find('.btn.btn-default.text-white.mt-5.btn-round').click
         expect(page).to have_content 'Create New User'
-        expect(page).to have_content "Password confirmation doesn't match Password"
+        if I18n.locale == :en
+          expect(page).to have_content "Password confirmation doesn't match Password"
+        else
+          expect(page).to have_content 'Password confirmationとPasswordの入力が一致しません'
+        end
       end
     end
 


### PR DESCRIPTION
i18nを導入して日本語に対応させる。
テストを日本語と英語で両方書いたが、メンテナンスコストを考えて次回以降は日本語のみテストする。

■その他実施項目
・viewportの設定
・containerの追加
#29 